### PR TITLE
Added section numbers to transactions header, removed top level heade…

### DIFF
--- a/input/pagecontent/volume-1.md
+++ b/input/pagecontent/volume-1.md
@@ -1,6 +1,4 @@
 
-# 1:XX Profile name
-
 **TODO: Provide an end-user friendly overview of what the profile does for them. Keep it brief (a paragraph or two, up to a page). If extensive detail is needed, it should be included in Section XX.4- Use Cases.**
 
 **TODO: Explicitly state whether this is a Workflow, Transport, or Content Module (or combination) profile. See the IHE Technical Frameworks General Introduction for definitions of these profile types. The IHE Technical Frameworks [General Introduction](https://profiles.ihe.net/GeneralIntro/). **
@@ -79,11 +77,11 @@ The Sever processes query request from the Client actor.
 
 FHIR Capability Statement for [Server](CapabilityStatement-IHE.ToDo.server.html)
 
-### Transaction Descriptions
+### XX.1.2 Transaction Descriptions
 
 The transactions in this profile are summarized in the sections below.
 
-#### ToDo do transaction
+#### XX.1.2.1 ToDo do transaction
 
 This transaction is used to **do things**
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -85,7 +85,7 @@ menu:
   Home: index.html
   Volume 1:
     Introduction: volume-1.html
-    Actors, Transactions, and Content Modules: volume-1.html#actors-and-transactions
+    Actors and Transactions: volume-1.html#actors-and-transactions
     Actor Options: volume-1.html#actor-options
     Required Actor Groupings: volume-1.html#required-groupings
     Overview: volume-1.html#overview

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -85,9 +85,9 @@ menu:
   Home: index.html
   Volume 1:
     Introduction: volume-1.html
-    Actors and Transactions: volume-1.html#actors-and-transactions
+    Actors, Transactions, and Content Modules: volume-1.html#actors-and-transactions
     Actor Options: volume-1.html#actor-options
-    Required Groupings: volume-1.html#required-groupings
+    Required Actor Groupings: volume-1.html#required-groupings
     Overview: volume-1.html#overview
     Security Considerations: volume-1.html#security-considerations
     Cross-Profile Considerations: volume-1.html#other-grouping


### PR DESCRIPTION
Minor updates.
* removed top header from volume 1 as the IG publisher automatically adds it.
* added header number for 1.2
* aligned menu with volume 1 headers.  These don't include the profile name in the menu, but is in volume 1.